### PR TITLE
add wp-block-converter

### DIFF
--- a/tools/classic-to-gutenberg/README.md
+++ b/tools/classic-to-gutenberg/README.md
@@ -1,5 +1,5 @@
 # Classic to Gutenberg
 
 ## Tools
-- [Convert to Blocks](https://github.com/10up/convert-to-blocks) 
-
+- [Convert to Blocks](https://github.com/10up/convert-to-blocks)
+- [WP Block Converter](https://github.com/alleyinteractive/wp-block-converter)


### PR DESCRIPTION
Add the **wp block converter** to the `classic to Gutenberg` tools list.