### PR TITLE
add Figma embed block reference

### DIFF
--- a/tools/figma-to-blocks/README.md
+++ b/tools/figma-to-blocks/README.md
@@ -4,4 +4,4 @@ This README provides a curated list of tools for converting Figma designs into G
 
 ## Tools
 
-No tools yet!
+- [Figma embed block](https://github.com/10up/figma-block)


### PR DESCRIPTION
## What does the code do?
This PR adds an example in the Figma-to-blocks section of the Figma embed block plugin.

## Code Checklist
- [x] It contains a `readme.md` in the root directory.
  - [x] The readme explains how to use the tool.
  - [ ] The readme explains how to develop the tool.
- [x] This code has a GPL-compatible license.
- [x] This code follows [plugin guidelines](https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/
#the-guidelines).
- [x] I am the original author of this code.
