### PR TITLE
Link to Try WordPress browser extension from main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Rather than each person or organization needing to figure out a migration pathwa
 
 ## Primary Initiatives
 
+* [Try WordPress: Import your existing website to WordPress in an intuitive way](https://github.com/WordPress/try-wordpress)
 * [Migrating from third-party platforms to WordPress](https://github.com/WordPress/data-liberation/issues/60)
 * [WordPress to WordPress migrations](https://github.com/WordPress/data-liberation/issues/73)
 * [Migrating between Editors and Core/Third Party Blocks](https://github.com/WordPress/data-liberation/issues/59)


### PR DESCRIPTION
@ashfame @akirk and myself have been working on a browser extension that makes it easy to import a site to WordPress directly from the browser, in an interactive way, that shows an immediate preview of the new WordPress site.

We would like to link to the GitHub project of Try WordPress from the *Main Initiatives* section of the README.md.
