### PR TITLE
Add WEFG tools listing

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -4,6 +4,10 @@ This is a curated list of valuable tools and resources created by our community 
 
 ## Tools by category
 
+### Exporting
+
+- [WEFG](https://github.com/WordPress/data-liberation/tree/trunk/tools/wefg) - Tools for generating WordPress WXR from any CMS, including custom ones
+
 ### Importing
 
 - [Keyring Social Importer](https://github.com/WordPress/data-liberation/tree/trunk/tools/keyring-importer) - Tool to import content from various Social Media sources

--- a/tools/wefg/README.md
+++ b/tools/wefg/README.md
@@ -1,0 +1,8 @@
+# WEFG
+
+Tools for generating WordPress WXR from any CMS, including custom ones.
+
+## Tools
+
+- [WEFG](https://github.com/raicem/wefg) - PHP library for programmatically generating WXR files.
+- [WEFG No Code](https://github.com/raicem/wefg-no-code) - Prompt-driven toolkit for generating and verifying WXR exporter code with AI.

--- a/tools/wefg/README.md
+++ b/tools/wefg/README.md
@@ -1,8 +1,26 @@
 # WEFG
 
-Tools for generating WordPress WXR from any CMS, including custom ones.
+Library for generating WordPress WXR from any CMS, including custom ones.
+
+## Quick example
+
+The WEFG library lets you describe a WXR file in PHP. You can generate valid WordPress import files from any CMS, including custom ones.
+
+```php
+$wxr = new WXRFile($settings);
+$wxr->addPost(new Post(
+    title: 'Hello World',
+    content: '<p>Welcome to my site.</p>',
+    authorLogin: 'admin',
+    publishDate: '2024-01-01 12:00:00',
+    slug: 'hello-world'
+));
+$wxr->save('export.xml');
+```
+
+`wefg-no-code` builds on the same idea, but helps AI agents generate the exporter itself. That makes it possible to create a WXR exporter in any language or framework and validate it against a real WordPress import workflow.
 
 ## Tools
 
 - [WEFG](https://github.com/raicem/wefg) - PHP library for programmatically generating WXR files.
-- [WEFG No Code](https://github.com/raicem/wefg-no-code) - Prompt-driven toolkit for generating and verifying WXR exporter code with AI.
+- [WEFG No Code](https://github.com/raicem/wefg-no-code) - Agent toolkit for generating and verifying WXR exporter code in any language.


### PR DESCRIPTION
## What does the code do?

Adds a new `tools/wefg` entry to the community tools list.

This groups the WEFG libraries under a single folder and links to:
- `raicem/wefg` - https://github.com/raicem/wefg
- `raicem/wefg-no-code` - https://github.com/raicem/wefg-no-code

It also adds a top-level entry in `tools/README.md` under `Exporting` since these tools help you export your data and then relies on the default WordPress importer. 
