### PR TITLE
Refresh Drupal to WordPress migration guide

### DIFF
--- a/guides/drupal-to-wordpress.md
+++ b/guides/drupal-to-wordpress.md
@@ -1,20 +1,33 @@
 # Drupal to WordPress
 
-🚧 **This Guide is a Work in Progress! We Need Your Help!** 🚧
+Keep the Drupal site available until the migrated content has been checked. The safest workflow is to import into a staging WordPress site, resolve content and URL differences there, and schedule the production cutover only after testing.
 
-We are in the process of creating a comprehensive guide to help users migrate from Drupal to WordPress. Your insights and contributions are invaluable to make this guide more complete and helpful for the community.
+## Prepare both sites
 
-## How You Can Contribute
+- Back up the Drupal database and files, including uploaded media and configuration exports.
+- Record the Drupal version, site URL, languages, content types, vocabularies, users, comments, custom fields, and important URL patterns.
+- Install WordPress on staging with enough storage for the Drupal media library. Do not change the production domain yet.
 
-- **Review and Edit:** If you have experience with Drupal to WordPress migration, review the existing content, and make edits for accuracy and clarity.
+## Import Drupal content
 
-- **Add Missing Steps:** If you notice any steps missing or have additional tips, please contribute by adding them to the guide.
+The [FG Drupal to WordPress](https://wordpress.org/plugins/fg-drupal-to-wp/) plugin is a practical starting point. Review the plugin page for current Drupal-version support, requirements, and premium extensions before beginning.
 
-- **Share Your Experience:** Share your personal experience or best practices that can benefit others going through the migration process.
+1. In WordPress, go to **Plugins > Add New**, install and activate **FG Drupal to WordPress**, and open its importer under **Tools > Import**.
+2. Enter the Drupal database connection details requested by the importer. If the target server cannot reach the Drupal database, follow the plugin’s documented alternative for a database export or remote connection.
+3. Select the Drupal content types, users, comments, terms, and media to import. Keep the source site reachable if images must be downloaded from its public URLs.
+4. Run a small test import first. Check the results, correct the mapping or settings, and then run the remaining content in batches when the importer supports it.
+5. Save the importer report and keep the original Drupal backup until the new site is live and verified.
 
-Many resources are available to help you migrate content from Drupal to WordPress. A few are highlighted here, and you’re likely to find many others by searching the web.
+## Map Drupal features to WordPress
 
-1. [FG Drupal to WordPress](https://wordpress.org/plugins/fg-drupal-to-wp/): This is compatible with Drupal 6, 7, and 8.
-2. [Drupal2WordPress Plugin](https://github.com/jpSimkins/Drupal2WordPress-Plugin): Use this plugin to import terms, content, media, comments, and users. Any external images included in your Drupal site can be fetched and added to the media library and added to your pages and posts.
-3. [This tutorial](http://anothercoffee.net/drupal-to-wordpress-migration-explained/) includes workarounds for some migration issues such as duplicate terms, terms exceeding the maximum character length, and duplicate URL aliases.
-4. [How to Convert Drupal to WordPress](http://blondish.net/how-to-convert-drupal-to-wordpress/).
+An importer moves content; it does not recreate every Drupal module or theme. Map Drupal content types to WordPress post types, vocabularies to taxonomies, and custom fields to post meta or a suitable WordPress plugin. Rebuild menus, blocks, views, forms, search, and other module-provided features separately.
+
+## Verify and cut over
+
+- Compare a representative sample of posts, pages, custom types, terms, authors, comments, dates, and formatting.
+- Confirm media files are in the WordPress media library and that content no longer references the Drupal host.
+- Preserve important URLs where possible. Add redirects for changed paths and check canonical URLs, feeds, and XML sitemaps.
+- Test search, forms, analytics, permissions, multilingual content, and any ecommerce or membership flows on staging.
+- Take a final backup, put Drupal into maintenance mode during cutover, and point the domain to WordPress only after the checks pass.
+
+For general importer guidance and troubleshooting, see [Importing Content](https://developer.wordpress.org/advanced-administration/wordpress/import/).


### PR DESCRIPTION
Closes #38

Replaces the work-in-progress Drupal guide with a practical staging-first workflow covering backups, the FG Drupal to WordPress importer, content mapping, media, redirects, and cutover verification.